### PR TITLE
Update title in QnA page

### DIFF
--- a/our-brothers-web/src/app/qna/page/qna-page.component.html
+++ b/our-brothers-web/src/app/qna/page/qna-page.component.html
@@ -4,7 +4,7 @@
   שאלות ותשובות
 </h1>
 <h2 class="medium-heading" data-aos="fade-up" data-aos-duration="1000">
-  עונים על הכל
+  לפניכם שאלות ותשובות נפוצות
 </h2>
 <div class="qna-types-list-container">
   <div class="container">


### PR DESCRIPTION
Update the title according to the PS file.

No other UI changes were found, there is not questions and answers list inside the PS

<img width="2256" alt="Screen Shot 2020-03-11 at 20 48 45" src="https://user-images.githubusercontent.com/33118325/76452767-52b78280-63da-11ea-933c-11df2a63afbd.png">
